### PR TITLE
Migrate to ES Modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const { Plugin } = require('release-it');
+import { Plugin } from 'release-it';
 
 class MyPlugin extends Plugin {}
 
-module.exports = MyPlugin;
+export default MyPlugin;

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "devDependencies": {
     "bron": "^2.0.3",
     "release-it": "^15.2.0",
-    "sinon": "^13.0.2"
+    "sinon": "^15.0.1"
   },
   "peerDependencies": {
     "release-it": "^15.2.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.9"
   },
   "release-it": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
   "homepage": "https://github.com/my/awesome-plugin#readme",
   "bugs": "https://github.com/my/awesome-plugin/issues",
   "author": "",
-  "peerDependencies": {
-    "release-it": "^15.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "bron": "^2.0.3",
-    "release-it": "^15.0.0"
+    "release-it": "^15.2.0"
+  },
+  "peerDependencies": {
+    "release-it": "^15.2.0"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {},
   "devDependencies": {
     "bron": "^2.0.3",
-    "release-it": "^15.2.0"
+    "release-it": "^15.2.0",
+    "sinon": "^13.0.2"
   },
   "peerDependencies": {
     "release-it": "^15.2.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0",
   "description": "My plugin for release-it",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "bron test.js",
     "release": "release-it"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "my-plugin",
   "version": "0.0.0",
   "description": "My plugin for release-it",
-  "main": "index.js",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
     "test": "bron test.js",
     "release": "release-it"

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
-const test = require('bron');
-const assert = require('assert').strict;
-const { factory, runTasks } = require('release-it/test/util');
-const Plugin = require('.');
+import test from 'bron';
+import assert from 'assert/strict';
+import { factory, runTasks } from 'release-it/test/util/index.js';
+import Plugin from './index.js';
 
 const namespace = 'my-plugin';
 


### PR DESCRIPTION
Follow release-it v15 and main plugins migration to ES Modules.

- declare `type: module` and use `import`/`export`
- update `release-it` dep for its `exports` to be "complete" (`test/util` fixed in [15.1.3](https://github.com/release-it/release-it/releases/tag/15.1.3), and `./package.json` added in [15.2.0](https://github.com/release-it/release-it/releases/tag/15.2.0))
- correct exports (like https://github.com/release-it/conventional-changelog/commit/b19b6e826e82dce02b0f8c64e47c72a192028bda, and https://github.com/release-it/release-it/commit/acc66f7c628d5797594714bb19f8d8e4699d014d)
- add mandatory `sinon` devDep since used in `test/util`

Fixing 2 errors to run test.

> ✖ test.js
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './test/util' is not defined by "exports" in C:\plugin-starterkit\node_modules\release-it\package.json imported from C:\plugin-starterkit\test.js

> 
> ✖ test.js
> Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'sinon' imported from C:\plugin-starterkit\node_modules\release-it\test\util\index.js